### PR TITLE
Provide alternative to getrandom(2) for GLIBC < 2.25

### DIFF
--- a/configure
+++ b/configure
@@ -43,4 +43,16 @@ if compiles "-D_POSIX_C_SOURCE=200112L" "
 	}"
 then
 	echo "CFLAGS += -DHAVE_GETRANDOM" >> config.mk
+
+elif compiles "-D_GNU_SOURCE" "
+    #include <unistd.h>
+    #include <sys/syscall.h>
+    int main(void)
+    {
+        long n = SYS_getrandom;
+        long (*p)(long, ...) = syscall;
+        return (intptr_t)p & n;
+    }"
+then
+    echo "CFLAGS += -D_GNU_SOURCE -DHAVE_GETRANDOM_SYSCALL" >> config.mk
 fi

--- a/configure
+++ b/configure
@@ -45,14 +45,14 @@ then
 	echo "CFLAGS += -DHAVE_GETRANDOM" >> config.mk
 
 elif compiles "-D_GNU_SOURCE" "
-    #include <unistd.h>
-    #include <sys/syscall.h>
-    int main(void)
-    {
-        long n = SYS_getrandom;
-        long (*p)(long, ...) = syscall;
-        return (intptr_t)p & n;
-    }"
+	#include <unistd.h>
+	#include <sys/syscall.h>
+	int main(void)
+	{
+		long n = SYS_getrandom;
+		long (*p)(long, ...) = syscall;
+		return (intptr_t)p & n;
+	}"
 then
-    echo "CFLAGS += -DHAVE_GETRANDOM_SYSCALL" >> config.mk
+	echo "CFLAGS += -DHAVE_GETRANDOM_SYSCALL" >> config.mk
 fi

--- a/configure
+++ b/configure
@@ -54,5 +54,5 @@ elif compiles "-D_GNU_SOURCE" "
         return (intptr_t)p & n;
     }"
 then
-    echo "CFLAGS += -D_GNU_SOURCE -DHAVE_GETRANDOM_SYSCALL" >> config.mk
+    echo "CFLAGS += -DHAVE_GETRANDOM_SYSCALL" >> config.mk
 fi

--- a/smtp.c
+++ b/smtp.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -14,8 +15,13 @@ static void get_random_bytes(void *buf, size_t n)
 {
 #if defined HAVE_ARC4RANDOM  /* BSD */
 	arc4random_buf(buf, n);
-#elif defined HAVE_GETRANDOM /* Linux */
+#elif defined HAVE_GETRANDOM /* Linux, GLIBC >= 2.25 */
 	getrandom(buf, n, 0);
+#elif defined __linux__ && defined __GLIBC__ && \
+    __GLIBC__ <= 2 &&  __GLIBC_MINOR__ < 25 /* Linux, GLIBC < 2.25 */
+    #include <unistd.h>
+    #include <sys/syscall.h>
+    syscall(SYS_getrandom, buf, n, 0);
 #else
 #error OS does not provide recognized function to get entropy
 #endif

--- a/smtp.c
+++ b/smtp.c
@@ -1,4 +1,3 @@
-#define _GNU_SOURCE
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -7,6 +6,9 @@
 #include <time.h>
 #ifdef HAVE_GETRANDOM
 #include <sys/random.h>
+#elif defined HAVE_GETRANDOM_SYSCALL
+#include <unistd.h>
+#include <sys/syscall.h>
 #endif
 
 #include "smtp.h"
@@ -17,10 +19,7 @@ static void get_random_bytes(void *buf, size_t n)
 	arc4random_buf(buf, n);
 #elif defined HAVE_GETRANDOM /* Linux, GLIBC >= 2.25 */
 	getrandom(buf, n, 0);
-#elif defined __linux__ && defined __GLIBC__ && \
-    __GLIBC__ <= 2 &&  __GLIBC_MINOR__ < 25 /* Linux, GLIBC < 2.25 */
-    #include <unistd.h>
-    #include <sys/syscall.h>
+#elif defined HAVE_GETRANDOM_SYSCALL
     syscall(SYS_getrandom, buf, n, 0);
 #else
 #error OS does not provide recognized function to get entropy

--- a/smtp.c
+++ b/smtp.c
@@ -23,7 +23,7 @@ static void get_random_bytes(void *buf, size_t n)
 #elif defined HAVE_GETRANDOM /* Linux, GLIBC >= 2.25 */
 	getrandom(buf, n, 0);
 #elif defined HAVE_GETRANDOM_SYSCALL
-    syscall(SYS_getrandom, buf, n, 0);
+	syscall(SYS_getrandom, buf, n, 0);
 #else
 #error OS does not provide recognized function to get entropy
 #endif

--- a/smtp.c
+++ b/smtp.c
@@ -1,3 +1,6 @@
+#ifdef HAVE_GETRANDOM_SYSCALL
+#define _GNU_SOURCE
+#endif
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
`getrandom(2)` has been introduced in GLIBC 2.25
For versions <= 2.24, provide an alternative directly using the syscall.